### PR TITLE
Improve news date format

### DIFF
--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -9,7 +9,10 @@
 		<%= link_to 'Redigera', edit_news_path(@news) %>
     <%= link_to 'Tillbaka', news_index_path %>
 		<% end %>
-        <h5><%= l @news.created_at, format: '%e %B %Y' %> av <%= @news.user.name if @news.user %></h5>
+        <h5>
+          <%= l @news.created_at, format: (@news.created_at < 2.days.ago ? '%e %B %Y' : :long) %>
+          <%= "av #{@news.user.name}" if @news.user %>
+        </h5>
 
         <div class="page-content news-content">
           <%= GitHub::Markdown.render_gfm(@news.body).html_safe %>

--- a/app/views/news/show.html.erb
+++ b/app/views/news/show.html.erb
@@ -9,7 +9,7 @@
 		<%= link_to 'Redigera', edit_news_path(@news) %>
     <%= link_to 'Tillbaka', news_index_path %>
 		<% end %>
-        <h5>Skapad <%= distance_of_time_in_words_to_now(@news.created_at) %> av <%= @news.user.name if @news.user %></h5>
+        <h5><%= l @news.created_at, format: '%e %B %Y' %> av <%= @news.user.name if @news.user %></h5>
 
         <div class="page-content news-content">
           <%= GitHub::Markdown.render_gfm(@news.body).html_safe %>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -41,7 +41,10 @@
       <% @latest_post.each do |single_post| %>
         <div class="pane">
           <h3><%= link_to single_post.title, public_news_path(single_post) %></h3>
-          <h5><%= l single_post.created_at, format: '%e %B %Y' %> av <%= single_post.user.name %></h5>
+          <h5>
+            <%= l single_post.created_at, format: (single_post.created_at < 2.days.ago ? '%e %B %Y' : :long) %>
+            <%= "av #{single_post.user.name}" if single_post.user %>
+          </h5>
           <div class="page-content news-content">
             <%= GitHub::Markdown.render_gfm(single_post.body).html_safe %>
           </div>

--- a/app/views/static_pages/home.html.erb
+++ b/app/views/static_pages/home.html.erb
@@ -41,7 +41,7 @@
       <% @latest_post.each do |single_post| %>
         <div class="pane">
           <h3><%= link_to single_post.title, public_news_path(single_post) %></h3>
-          <h5>Skapad <%= distance_of_time_in_words_to_now(single_post.created_at) %> av <%= single_post.user.name %></h5>
+          <h5><%= l single_post.created_at, format: '%e %B %Y' %> av <%= single_post.user.name %></h5>
           <div class="page-content news-content">
             <%= GitHub::Markdown.render_gfm(single_post.body).html_safe %>
           </div>


### PR DESCRIPTION
Instead of using the time ago structure, it now posts the absolute date (no time).

This should close #27, so add `Fixes #27` to the merge commit message and it should close.