### PR TITLE
News are ordered with the latest at the top

### DIFF
--- a/app/controllers/news_controller.rb
+++ b/app/controllers/news_controller.rb
@@ -5,7 +5,7 @@ class NewsController < ApplicationController
   # GET /news
   # GET /news.json
   def index
-    @news = News.all
+    @news = News.all.order('updated_at DESC')
   end
 
   # GET /news/1
@@ -75,3 +75,4 @@ class NewsController < ApplicationController
       params.require(:news).permit(:title, :body, :published, :user_id)
     end
 end
+


### PR DESCRIPTION
fixes #114, The list of news are now sorted in reverse order, i. e. the latest news is at the top. It currently looks at  "updated_at"