### PR TITLE
Remove `rake cleanup` from post deployment instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,3 @@ deploy:
   run:
     - "rake db:migrate"
     - restart
-    - "rake cleanup"


### PR DESCRIPTION
It only caused errors and the asset compilation process on Heroku takes
care of it already.

💩 