### PR TITLE
Replace default_scope with scopes for sorting

### DIFF
--- a/app/controllers/drink_types_controller.rb
+++ b/app/controllers/drink_types_controller.rb
@@ -6,7 +6,7 @@ class DrinkTypesController < ApplicationController
   # GET /drink_types
   # GET /drink_types.json
   def index
-    @drink_types = DrinkType.all
+    @drink_types = DrinkType.ordered_by_name.all
     @updated = Drink.order('updated_at').last.updated_at
     @drank = []
     @drink_types.each do |dt|
@@ -19,7 +19,7 @@ class DrinkTypesController < ApplicationController
   # GET /drink_types/1
   # GET /drink_types/1.json
   def show
-    @drinks = @drink_type.drinks
+    @drinks = @drink_type.drinks.ordered_by_name
     @drank = []
     @drinks.each do |d|
       @drank.push(d.slug) if cookies[d.slug]

--- a/app/models/drink.rb
+++ b/app/models/drink.rb
@@ -2,7 +2,7 @@ class Drink < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name, use: [:slugged, :history]
 
-  default_scope { order(name: :asc) }
+  scope :ordered_by_name, -> { order(name: :asc) }
 
   belongs_to :drink_type
   validates :drink_type, presence: :true

--- a/app/models/drink_type.rb
+++ b/app/models/drink_type.rb
@@ -2,7 +2,7 @@ class DrinkType < ActiveRecord::Base
   extend FriendlyId
   friendly_id :name, use: :slugged
 
-  default_scope { order(name: :asc) }
+  scope :ordered_by_name, -> { order(name: :asc) }
 
   has_many :drinks
 end

--- a/app/views/drink_types/index.json.jbuilder
+++ b/app/views/drink_types/index.json.jbuilder
@@ -3,9 +3,8 @@ json.drink_list(@drink_types) do |drink_type|
   json.extract! drink_type, :id, :name, :description
   json.url stock_url(drink_type)
   json.admin_url edit_drink_type_url(drink_type)
-  json.drinks drink_type.drinks.ordered_by_name.where(instock: true)
-    .select('name', 'country', 'price', 'slug', 'brewery') do |drink|
-
+  drink_params = %w(name country price slug brewery)
+  json.drinks drink_type.drinks.ordered_by_name.where(instock: true).select(drink_params) do |drink|
     json.url stock_drink_url(drink_type, drink)
     json.name drink.name
     json.brewery drink.brewery

--- a/app/views/drink_types/index.json.jbuilder
+++ b/app/views/drink_types/index.json.jbuilder
@@ -3,7 +3,7 @@ json.drink_list(@drink_types) do |drink_type|
   json.extract! drink_type, :id, :name, :description
   json.url stock_url(drink_type)
   json.admin_url edit_drink_type_url(drink_type)
-  json.drinks drink_type.drinks.where(instock: true).select('name', 'country', 'price', 'slug', 'brewery') do |drink|
+  json.drinks drink_type.drinks.ordered_by_name.where(instock: true).select('name', 'country', 'price', 'slug', 'brewery') do |drink|
     json.url stock_drink_url(drink_type, drink)
     json.name drink.name
     json.brewery drink.brewery

--- a/app/views/drink_types/index.json.jbuilder
+++ b/app/views/drink_types/index.json.jbuilder
@@ -3,7 +3,9 @@ json.drink_list(@drink_types) do |drink_type|
   json.extract! drink_type, :id, :name, :description
   json.url stock_url(drink_type)
   json.admin_url edit_drink_type_url(drink_type)
-  json.drinks drink_type.drinks.ordered_by_name.where(instock: true).select('name', 'country', 'price', 'slug', 'brewery') do |drink|
+  json.drinks drink_type.drinks.ordered_by_name.where(instock: true)
+    .select('name', 'country', 'price', 'slug', 'brewery') do |drink|
+
     json.url stock_drink_url(drink_type, drink)
     json.name drink.name
     json.brewery drink.brewery


### PR DESCRIPTION
Since you cant override the default scope (even explicitly), I think we should avoid using it.
Instead I've added a scope to get both drinks and drink_types ordered by name